### PR TITLE
Fix translucent dialogues and drop-downs

### DIFF
--- a/themes/kibibit.yaml
+++ b/themes/kibibit.yaml
@@ -57,7 +57,7 @@ kibibit:
   label-badge-text-color: "#F1F1F1"
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  card-background-color: rgba(25, 25, 25, 1) # More info dialog background, Unused entities table background
   paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: 'rgba(150, 150, 150, 0.1)'
@@ -139,7 +139,7 @@ kibibit-dark-cards:
   label-badge-text-color: "#F1F1F1"
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  card-background-color: rgba(25, 25, 25, 1) # More info dialog background, Unused entities table background
   paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: 'rgba(0, 0, 0, 0.3)'


### PR DESCRIPTION
Fix destructive translucent dialogue and drop-down list backgrounds.

Examples of an issue:
![theme_issue_1](https://user-images.githubusercontent.com/1819786/108372098-1fdf5680-7207-11eb-9a91-d394fdbc4333.png)
![theme_issue_2](https://user-images.githubusercontent.com/1819786/108372109-2241b080-7207-11eb-9e03-8446baae0df7.png)
